### PR TITLE
📦 Bump to lodash 4

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
   "dependencies": {
     "bluebird": "2",
     "create-error": "0.3",
-    "needle": "clearbit/needle#84d28b5f2c3916db1e7eb84aeaa9d976cc40054b",
-    "lodash": "2"
+    "lodash": "4.x",
+    "needle": "clearbit/needle#84d28b5f2c3916db1e7eb84aeaa9d976cc40054b"
   },
   "devDependencies": {
     "chai": "1",

--- a/src/client.js
+++ b/src/client.js
@@ -79,7 +79,7 @@ ClearbitClient.prototype.request = function (options) {
   .spread(function (response, body) {
     if (response.statusCode === 202 || response.statusCode >= 400) {
       var message = body.error ? body.error.message : http.STATUS_CODES[response.statusCode] || 'Unknown';
-      throw _.extend(new this.ClearbitError(message), {
+      throw _.assign(new this.ClearbitError(message), {
         type: body.error ? body.error.type : 'unknown',
         body: body,
         statusCode: response.statusCode

--- a/src/resource.js
+++ b/src/resource.js
@@ -5,11 +5,11 @@ var _           = require('lodash');
 
 function ClearbitResource (data) {
   this.options = {};
-  _.extend(this, data);
+  _.assign(this, data);
 }
 
 ClearbitResource.get = function (path, options) {
-  options = _.extend({
+  options = _.assign({
     path:   path,
     method: 'get',
     query: extractParams(options)
@@ -27,7 +27,7 @@ ClearbitResource.get = function (path, options) {
 };
 
 ClearbitResource.post = function (path, options) {
-  options = _.extend({
+  options = _.assign({
     path:   path,
     method: 'post',
     json:   true,
@@ -43,7 +43,7 @@ ClearbitResource.post = function (path, options) {
 };
 
 ClearbitResource.del = function (path, options) {
-  options = _.extend({
+  options = _.assign({
     path:   path,
     method: 'delete'
   }, this.options, options);
@@ -66,20 +66,20 @@ exports.create = function (name, options) {
     ClearbitResource.apply(this, arguments);
   };
 
-  _.extend(Resource, ClearbitResource, createErrors(name), {
+  _.assign(Resource, ClearbitResource, createErrors(name), {
     name: name,
     options: options
   });
 
-  return _.extend(function (client) {
-    return _.extend(Resource, {
+  return _.assign(function (client) {
+    return _.assign(Resource, {
       client: client
     });
   },
   {
     extend: function (proto, ctor) {
-      _.extend(Resource.prototype, proto);
-      _.extend(Resource, ctor);
+      _.assign(Resource.prototype, proto);
+      _.assign(Resource, ctor);
       return this;
     }
   });
@@ -108,11 +108,11 @@ function createErrors (name) {
 }
 
 function extractParams (options) {
-  var params = _.omit(options || {},
+  var params = _.omit(options || {}, [
     'path', 'method', 'params',
     'client', 'api', 'stream',
     'headers', 'timeout'
-  );
+  ]);
 
   return _.isEmpty(params) ? null : params;
 }


### PR DESCRIPTION
This is to fix the following security vulnerabilities, now flagged as **high** by npm audit:
https://npmjs.com/advisories/577
https://npmjs.com/advisories/782
https://npmjs.com/advisories/1065

Also related to https://github.com/clearbit/clearbit-node/issues/20

I ran the tests locally and they are all passing.

## migration

There are 4 lodash functions used in the library:
* extend
* omit
* isEmpty
* defaults

Previous version was lodash 2, for which the doc is [here](https://lodash.com/docs/2.4.2)
New version is lodash 4, for which the doc is [here](https://lodash.com/docs/4.17.15)

Going through the migration, one function at a time.

### omit
https://lodash.com/docs/2.4.2#omit
https://lodash.com/docs/4.17.15#omit
Same thing here except that the `callback` way to use the function is no longer available in lodash 4. I added the property names as an array just for clarity.

### isEmpty
https://lodash.com/docs/2.4.2#isEmpty
https://lodash.com/docs/4.17.15#isEmpty
Function signature is the same, the new version seems to be handling more data types, and that's it.

### defaults
https://lodash.com/docs/2.4.2#defaults
https://lodash.com/docs/4.17.15#defaults
looks like only the documentation changed, to mention that only **string** keyed properties are used from the source object.

### extend
https://lodash.com/docs/2.4.2#assign
https://lodash.com/docs/4.17.15#assignIn
https://lodash.com/docs/4.17.15#assign

This one is a bit trickier. The difference between `extend` (`assign`) in lodash 2 and `extend` (`assignIn`) in lodash 4 is that `assignIn` "iterates over own and inherited source properties", whereas lodash 4 `assign` and lodash 2 `assign` and `extend` only iterated over the objects' own property (I tested that in the REPL of lodash 2). Since the `extend` alias switched from `assign` to `assignIn`, I changed to `assign` explicitly to preserve the behavior.
